### PR TITLE
Apply target for TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,9 +1059,9 @@
       }
     },
     "typescript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.1.tgz",
-      "integrity": "sha512-zQIMOmC+372pC/CCVLqnQ0zSBiY7HHodU7mpQdjiZddek4GMj31I3dUJ7gAs9o65X7mnRma6OokOkc6f9jjfBg==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
       "dev": true
     },
     "unpipe": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/chai-http": "^3.0.5",
     "@types/mocha": "^5.2.5",
     "tslint": "^5.11.0",
-    "typescript": "^3.0.1"
+    "typescript": "^3.1.6"
   },
   "dependencies": {
     "@types/express": "^4.17.0",


### PR DESCRIPTION
Apply target `typescript-version::typescript-version`:

**TypeScript version**
_TypeScript version_ > ```^3.1.6```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:typescript-version::typescript-version=bc832fb01c2c6aba9c60bb07d322c372fe9e1f1a5b2a3c71c69188c8b7a8e472]</code>
</details>